### PR TITLE
Include classic Nest login support

### DIFF
--- a/custom_components/badnest/__init__.py
+++ b/custom_components/badnest/__init__.py
@@ -3,15 +3,19 @@ import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 
 from .api import NestAPI
-from .const import DOMAIN, CONF_ISSUE_TOKEN, CONF_COOKIE
+from .const import DOMAIN, CONF_ISSUE_TOKEN, CONF_COOKIE, CONF_USER_ID, CONF_ACCESS_TOKEN
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
             {
+                vol.Required(CONF_USER_ID, default=""): cv.string,
+                vol.Required(CONF_ACCESS_TOKEN, default=""): cv.string,
+            },
+            {
                 vol.Required(CONF_ISSUE_TOKEN, default=""): cv.string,
                 vol.Required(CONF_COOKIE, default=""): cv.string,
-            }
+            },
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -21,14 +25,20 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the badnest component."""
     if config.get(DOMAIN) is not None:
+        user_id = config[DOMAIN].get(CONF_USER_ID)
+        access_token = config[DOMAIN].get(CONF_ACCESS_TOKEN)
         issue_token = config[DOMAIN].get(CONF_ISSUE_TOKEN)
         cookie = config[DOMAIN].get(CONF_COOKIE)
     else:
+        user_id = None
+        access_token = None
         issue_token = None
         cookie = None
 
     hass.data[DOMAIN] = {
         'api': NestAPI(
+            user_id,
+            access_token,
             issue_token,
             cookie,
         ),

--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -83,12 +83,14 @@ class AuthorizationRequired(Exception):
 
 class NestAPI():
     def __init__(self,
+                 user_id,
+                 access_token,
                  issue_token,
                  cookie):
         self.device_data = {}
         self._wheres = {}
-        self._user_id = None
-        self._access_token = None
+        self._user_id = user_id
+        self._access_token = access_token
         self._retries = Retry(
             total=RETRY_NUM,
             backoff_factor=RETRY_BACKOFF,
@@ -137,6 +139,18 @@ class NestAPI():
         r.raise_for_status()
 
     def login(self):
+        if self._user_id and self._access_token:
+            self._login_dropcam()
+        else:
+            self._login_google()
+
+    def _login_dropcam(self):
+        self._session.post(
+            f"{API_URL}/dropcam/api/login",
+            data={"access_token": self._access_token}
+        )
+
+    def _login_google(self):
         headers = {
             'User-Agent': USER_AGENT,
             'Sec-Fetch-Mode': 'cors',

--- a/custom_components/badnest/const.py
+++ b/custom_components/badnest/const.py
@@ -1,3 +1,5 @@
 DOMAIN = 'badnest'
 CONF_ISSUE_TOKEN = 'issue_token'
 CONF_COOKIE = 'cookie'
+CONF_USER_ID = 'user_id'
+CONF_ACCESS_TOKEN = 'access_token'

--- a/info.md
+++ b/info.md
@@ -71,6 +71,35 @@ you stay logged into your Google Account).
     field/value pairs** - do not include the `cookie:` name).  This is your
     `"cookie"` in `configuration.yaml`.
 
+### Example configuration.yaml - When you are using the Nest Login
+
+```yaml
+badnest:
+  user_id: 1234567
+  access_token: "....."
+
+climate:
+  - platform: badnest
+    scan_interval: 10
+
+camera:
+  - platform: badnest
+
+sensor:
+  - platform: badnest
+```
+
+The values of `"user_id"` and `"access_token"` are specific to your Nest account.
+To get them, follow these steps:
+
+1. Open <https://home.nest.com> in Chrome.
+2. Open Developer Tools (View/Developer/Developer Tools).
+3. Click on 'Network' tab. Make sure 'Preserve Log' is checked.
+4. In the 'Filter' box, enter `session`
+5. Log into your account using your Nest login
+6. One network call (beginning with `session?_=`) will appear in the Dev Tools window.  Click on it.
+7. In the Response tab, find your `access_token` and `user_id` from the JSON response.
+
 ## Notes
 
 The target temperature reported by the integration sometimes _seems_ to be


### PR DESCRIPTION
Since the USA-RedDragon/badnest repository was taken down, I've wanted to reintroduce the classic Nest login capability in to this integration as that is still how I login to my Nest account.

This change allows the classic Nest login to be configured.  I have tested with 1x Thermostat, 1x Protect and 1x Camera.

The Camera actually needed an extra cookie to be set to work properly, which I've added in to the same login capability as I suspect it is specific to the Nest login.  However, if people are experiencing issues with their cams then maybe this fix needs expanding for Google login too.